### PR TITLE
docs: add README.pod

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -1,13 +1,13 @@
 ---
 name: tataku-processor-markdown_section
-description: A processor module for tataku.vim that re-interpret the chunk as markdown's sections.
+description: The processor module for tataku.vim that re-interprets the chunk as markdown sections.
 ---
 
 =pod
 
 =head1 tataku-processor-markdown_section X<tataku-processor-markdown_section>
 
-The processor module for tataku.vim that re-interpret the chunk as markdown's sections.
+The processor module for tataku.vim that re-interprets the chunk as markdown sections.
 
 =head2 Contents X<tataku-processor-markdown_section-contents>
 
@@ -23,7 +23,7 @@ The processor module for tataku.vim that re-interpret the chunk as markdown's se
 
 =head2 Dependencies X<tataku-processor-markdown_section-dependencies>
 
-This plugin needs below:
+This plugin requires the following:
 
 =over 0
 
@@ -35,7 +35,7 @@ This plugin needs below:
 
 =head2 Options X<tataku-processor-markdown_section-options>
 
-This module has any options.
+This module has no options.
 
 =head2 Samples X<tataku-processor-markdown_section-samples>
 

--- a/README.pod
+++ b/README.pod
@@ -5,4 +5,50 @@ description: A processor module for tataku.vim that re-interpret the chunk as ma
 
 =pod
 
+=head1 tataku-processor-markdown_section X<tataku-processor-markdown_section>
+
+The processor module for tataku.vim that re-interpret the chunk as markdown's sections.
+
+=head2 Contents X<tataku-processor-markdown_section-contents>
+
+=over 0
+
+=item * L<Dependencies|tataku-processor-markdown_section-dependencies>
+
+=item * L<Options|tataku-processor-markdown_section-options>
+
+=item * L<Samples|tataku-processor-markdown_section-samples>
+
+=back
+
+=head2 Dependencies X<tataku-processor-markdown_section-dependencies>
+
+This plugin needs below:
+
+=over 0
+
+=item * L<denops.vim|https://github.com/vim-denops/denops.vim>
+
+=item * L<tataku.vim|https://github.com/Omochice/tataku.vim>
+
+=back
+
+=head2 Options X<tataku-processor-markdown_section-options>
+
+This module has any options.
+
+=head2 Samples X<tataku-processor-markdown_section-samples>
+
+=begin vim
+
+let g:tataku_recipes = #{
+  \   sample: #{
+  \     processor: #{
+  \       name: 'markdown_section',
+  \     },
+  \   },
+  \ }
+
+=end vim
+
 =cut


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for tataku-processor-markdown_section with new overview, Contents, Dependencies, Options, and Samples sections.
  * Added a sample Vim snippet to demonstrate usage.
  * Clarified expected inputs/outputs and how to enable relevant options.
  * Purely documentation updates — no functional, public API, or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->